### PR TITLE
Menubar image, timer image and clock image turned into templates

### DIFF
--- a/src/Tomighty/Core/UI/TYDefaultStatusIcon.m
+++ b/src/Tomighty/Core/UI/TYDefaultStatusIcon.m
@@ -35,12 +35,13 @@ NSString * const ICON_STATUS_ALTERNATE = @"icon-status-alternate";
 - (NSStatusItem *)createStatusItem:(NSMenu *)menu
 {
     NSStatusItem *newStatusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-    
+    NSImage *iconImage = [self getIconImage:ICON_STATUS_IDLE];
+    iconImage.template = YES;
+
     [newStatusItem setHighlightMode:YES];
-    [newStatusItem setImage:[self getIconImage:ICON_STATUS_IDLE]];
-    [newStatusItem setAlternateImage:[self getIconImage:ICON_STATUS_ALTERNATE]];
+    [newStatusItem setImage:iconImage];
     [newStatusItem setMenu:menu];
-    
+
     return newStatusItem;
 }
 

--- a/src/Tomighty/TYAppDelegate.m
+++ b/src/Tomighty/TYAppDelegate.m
@@ -69,8 +69,12 @@
 }
 
 - (void)initMenuItemsIcons:(TYImageLoader *)imageLoader {
-    [self.remainingTimeMenuItem setImage:[imageLoader loadIcon:@"icon-clock"]];
-    [self.stopTimerMenuItem setImage:[imageLoader loadIcon:@"icon-stop-timer"]];
+    NSImage *clockIcon = [imageLoader loadIcon:@"icon-clock"];
+    clockIcon.template = YES;
+    NSImage *timerIcon = [imageLoader loadIcon:@"icon-stop-timer"];
+    timerIcon.template = YES;
+    [self.remainingTimeMenuItem setImage:clockIcon];
+    [self.stopTimerMenuItem setImage:timerIcon];
     [self.startPomodoroMenuItem setImage:[imageLoader loadIcon:@"icon-start-pomodoro"]];
     [self.startShortBreakMenuItem setImage:[imageLoader loadIcon:@"icon-start-short-break"]];
     [self.startLongBreakMenuItem setImage:[imageLoader loadIcon:@"icon-start-long-break"]];


### PR DESCRIPTION
Was annoyed by the fact that the Tomighty menu bar icon was invisible as per #14 so I made a quick fix. You just need to set the images as templates and they will render correctly in both modes.

Tested on OS X 10.10.1:

![Normal Mode](https://cloud.githubusercontent.com/assets/738351/5377500/979604ce-807a-11e4-9910-393f43c3aa99.png)

![Dark Mode](https://cloud.githubusercontent.com/assets/738351/5377502/991564ac-807a-11e4-9e3f-2e3e76ff82cf.png)
