### PR TITLE
Add Support for Dark Menu Bar Icons

### DIFF
--- a/src/Tomighty/Core/UI/TYDefaultStatusIcon.m
+++ b/src/Tomighty/Core/UI/TYDefaultStatusIcon.m
@@ -37,8 +37,8 @@ NSString * const ICON_STATUS_ALTERNATE = @"icon-status-alternate";
     NSStatusItem *newStatusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     
     [newStatusItem setHighlightMode:YES];
-    [newStatusItem setImage:[self getIconImage:ICON_STATUS_IDLE]];
-    [newStatusItem setAlternateImage:[self getIconImage:ICON_STATUS_ALTERNATE]];
+    [newStatusItem setImage:[self getIconImage:ICON_STATUS_IDLE template:YES]];
+    [newStatusItem setAlternateImage:[self getIconImage:ICON_STATUS_ALTERNATE template:YES]];
     [newStatusItem setMenu:menu];
     
     return newStatusItem;
@@ -46,16 +46,17 @@ NSString * const ICON_STATUS_ALTERNATE = @"icon-status-alternate";
 
 - (void)changeIcon:(NSString *)iconName
 {
-    [statusItem setImage:[self getIconImage:iconName]];
+    [statusItem setImage:[self getIconImage:iconName template:NO]];
 }
 
-- (NSImage *)getIconImage:(NSString *)iconName
+- (NSImage *)getIconImage:(NSString *)iconName template:(BOOL)isTemplate
 {
     NSImage *image = [iconImageCache objectForKey:iconName];
     if(!image)
     {
         image = [imageLoader loadIcon:iconName];
         iconImageCache[iconName] = image;
+        [image setTemplate:isTemplate];
     }
     return image;
 }


### PR DESCRIPTION
This allows the white icon to appear black on light menu bars, or to switch and appear white on the dark menu bars. The colorized versions of the icons remain unchanged.