### PR TITLE
Ticking bug fix

### DIFF
--- a/src/Tomighty/Core/Agent/TYSoundAgent.m
+++ b/src/Tomighty/Core/Agent/TYSoundAgent.m
@@ -41,6 +41,7 @@
     
     [eventBus subscribeTo:POMODORO_START subscriber:^(id timerContext)
     {
+        [soundPlayer stopCurrentLoop];
         if([preferences getInt:PREF_PLAY_TICKTOCK_SOUND_DURING_POMODORO])
         {
             [soundPlayer loop:SOUND_TIMER_TICK];
@@ -49,6 +50,7 @@
     
     [eventBus subscribeTo:BREAK_START subscriber:^(id timerContext)
     {
+        [soundPlayer stopCurrentLoop];
         if([preferences getInt:PREF_PLAY_TICKTOCK_SOUND_DURING_BREAK])
         {
             [soundPlayer loop:SOUND_TIMER_TICK];


### PR DESCRIPTION
There is a more minor bug that can be reproduced the following way:
- In 'Preferences' -> 'Notifications' -> 'Play tick tock sound during' check 'Pomodoro' and uncheck 'Break'.
- Start a pomodoro
- Start a short break (without stopping the pomodoro)

The ticking won't stop.
Alternatively if 'Pomodoro' is unchecked and 'Break' is checked then the same happens when a pomodoro is started during a short break.
