### PR TITLE
Added remaining seconds for last minute

### DIFF
--- a/src/Tomighty/Core/UI/TYDefaultAppUI.m
+++ b/src/Tomighty/Core/UI/TYDefaultAppUI.m
@@ -85,7 +85,11 @@
         [statusIcon setStatusText:@" Stopped"];
     } else {
         if (timeFormat == TYAppUIStatusIconTextFormatMinutes) {
-            text = [NSString stringWithFormat:@" %d m", minutes + (mode == TYAppUIRemainingTimeModeStart ? 0:1)];
+            if(minutes < 1){
+                text = [NSString stringWithFormat:@" %02d s", seconds];
+            } else {
+                text = [NSString stringWithFormat:@" %d m", minutes + (mode == TYAppUIRemainingTimeModeStart ? 0:1)];
+            }
         } else if (timeFormat == TYAppUIStatusIconTextFormatSeconds) {
             text = [NSString stringWithFormat:@" %02d:%02d", minutes, seconds];
         }

--- a/src/TomightyTests/Core/UI/TYAppUITests.m
+++ b/src/TomightyTests/Core/UI/TYAppUITests.m
@@ -147,6 +147,14 @@
 
 }
 
+- (void)test_update_remaining_time_to_fifty_nine_seconds_with_format_minutes
+{
+    [appUi setStatusIconTextFormat:TYAppUIStatusIconTextFormatMinutes];
+    
+    [appUi updateRemainingTime:59 withMode:TYAppUIRemainingTimeModeDefault];
+    [verify(statusIcon) setStatusText:@" 59 s"];
+}
+
 - (void)test_update_pomodoro_count_to_zero
 {
     [appUi updatePomodoroCount:0];


### PR DESCRIPTION
I use an app called Focus Time on my iPhone. One of the features of that app is that on the last minute, it changes to second visualization so you know that you are really in the last minute. I thought that it would be a good idea to add that feature here.

Code change is simple, and I added a test, although I have not been able to run the tests on my box. 

When running "test" from XCode:

> Showing Recent Issues
>
> Build target TomightyTests of project Tomighty with configuration Debug
>
> Check dependencies
>
> The file “Pods-TomightyTests.debug.xcconfig” couldn’t be opened because there is no such file. (/Users/rlbisbe/Dropbox/Proyectos/tomighty-osx/src/Pods/Target Support Files/Pods-TomightyTests/Pods-TomightyTests.debug.xcconfig)
>
> PhaseScriptExecution [CP]\ Check\ Pods\ Manifest.lock > /Users/rlbisbe/Library/Developer/Xcode/DerivedData/Tomighty-gtsabrygvzqomwgctcjjjijkqbef/Build/Intermediates/Tomighty.build/Debug/TomightyTests.build/Script-B7B8607396F24F888FD9E51D.sh
>     cd /Users/rlbisbe/Dropbox/Proyectos/tomighty-osx/src
    /bin/sh -c /Users/rlbisbe/Library/Developer/Xcode/DerivedData/Tomighty- gtsabrygvzqomwgctcjjjijkqbef/Build/Intermediates/Tomighty.build/Debug/TomightyTests.build/Script-B7B8607396F24F888FD9E51D.sh
>
> diff:** /../Podfile.lock: No such file or directory
> diff: /Manifest.lock: No such file or directory
> error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.



