### PR TITLE
Add Support for Do Not Disturb 

### DIFF
--- a/src/Tomighty/Base.lproj/PreferencesWindow.xib
+++ b/src/Tomighty/Base.lproj/PreferencesWindow.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1421" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
         <capability name="stacking Non-gravity area distributions on NSStackView" minToolsVersion="7.0" minSystemVersion="10.11"/>
@@ -11,6 +11,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="TYPreferencesWindowController">
             <connections>
                 <outlet property="check_continuous_mode" destination="K00-WD-P1n" id="dew-jz-0dY"/>
+                <outlet property="check_enable_do_not_disturb_during_pomodoro" destination="hm5-HW-XLi" id="Euw-1g-Jsf"/>
                 <outlet property="check_play_sound_when_timer_goes_off" destination="4gP-n3-o9H" id="FUX-Fi-uco"/>
                 <outlet property="check_play_sound_when_timer_starts" destination="UEf-gI-pZ6" id="VdU-XK-1aG"/>
                 <outlet property="check_play_ticktock_sound_during_break" destination="n8X-6J-yb1" id="fEo-Gf-VN3"/>
@@ -31,7 +32,7 @@
         <window title="Tomighty Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" showsToolbarButton="NO" frameAutosaveName="tomighty.window.preferences" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="196" y="240" width="393" height="253"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1129"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="393" height="253"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -267,8 +268,8 @@
                                     <rect key="frame" x="10" y="33" width="347" height="191"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ay4-lu-bRj">
-                                            <rect key="frame" x="53" y="80" width="179" height="17"/>
+                                        <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ay4-lu-bRj">
+                                            <rect key="frame" x="50" y="64" width="179" height="17"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="175" id="dZm-qd-6Yg"/>
                                             </constraints>
@@ -278,8 +279,8 @@
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <box autoresizesSubviews="NO" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="lBK-YY-ePX">
-                                            <rect key="frame" x="52" y="13" width="242" height="74"/>
+                                        <box autoresizesSubviews="NO" misplaced="YES" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="lBK-YY-ePX">
+                                            <rect key="frame" x="49" y="-2" width="242" height="74"/>
                                             <view key="contentView" id="Xg6-Cb-Sav">
                                                 <rect key="frame" x="1" y="1" width="240" height="58"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -316,8 +317,8 @@
                                                 </constraints>
                                             </view>
                                         </box>
-                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="UEf-gI-pZ6">
-                                            <rect key="frame" x="48" y="154" width="227" height="18"/>
+                                        <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UEf-gI-pZ6">
+                                            <rect key="frame" x="50" y="160" width="227" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="223" id="OBn-h1-2ac"/>
                                                 <constraint firstAttribute="height" constant="14" id="OUQ-u1-yKM"/>
@@ -330,8 +331,8 @@
                                                 <action selector="save_play_sound_when_timer_starts:" target="-2" id="R6Y-Rf-af0"/>
                                             </connections>
                                         </button>
-                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="4gP-n3-o9H">
-                                            <rect key="frame" x="48" y="134" width="244" height="18"/>
+                                        <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4gP-n3-o9H">
+                                            <rect key="frame" x="50" y="140" width="244" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="14" id="Zw4-ug-gct"/>
                                             </constraints>
@@ -343,8 +344,8 @@
                                                 <action selector="save_play_sound_when_timer_goes_off:" target="-2" id="DmH-Qw-rWX"/>
                                             </connections>
                                         </button>
-                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="Nlo-52-gcU">
-                                            <rect key="frame" x="48" y="114" width="251" height="18"/>
+                                        <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nlo-52-gcU">
+                                            <rect key="frame" x="50" y="120" width="251" height="18"/>
                                             <buttonCell key="cell" type="check" title="Show notifications when timers go off" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Bzh-st-EPg">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -352,6 +353,17 @@
                                             <connections>
                                                 <action selector="save_show_notifications:" target="-2" id="xXF-j5-KHh"/>
                                             </connections>
+                                        </button>
+                                        <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hm5-HW-XLi">
+                                            <rect key="frame" x="50" y="94" width="347" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="check" title="Enable Do Not Disturb during Pomodoro" bezelStyle="regularSquare" imagePosition="left" inset="2" id="9VL-Kp-dRg">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                                <connections>
+                                                    <action selector="save_enable_do_not_disturb_during_pomodoro:" target="-2" id="I5m-LS-Hh9"/>
+                                                </connections>
+                                            </buttonCell>
                                         </button>
                                     </subviews>
                                     <constraints>

--- a/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
+++ b/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
@@ -49,7 +49,7 @@
     [eventBus subscribeTo:POMODORO_START subscriber:^(id eventData) {
         [ui switchToPomodoroState];
         [self dispatchNewNotification:@"Pomodoro started"];
-        NSLog(@"%d --- ENABLE DND", [preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]);
+    
         if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                          1 * NSEC_PER_SEC),
@@ -70,22 +70,12 @@
                                      1 * NSEC_PER_SEC),
                        dispatch_get_main_queue(),
                        ^{
-                           NSLog(@"--- Pomodoro complete");
                            [self dispatchNewNotification:@"Pomodoro completed"];
                        });
         
     }];
     
     [eventBus subscribeTo:TIMER_STOP subscriber:^(id eventData) {
-        /*if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
-                                     1 * NSEC_PER_SEC),
-                       dispatch_get_main_queue(),
-                       ^{
-                           NSLog(@"--- DISABLE DND");
-                           turnDoNotDisturbOff();
-                       });
-        }*/
         if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
             turnDoNotDisturbOff();
         }
@@ -165,7 +155,6 @@ void turnDoNotDisturbOff()
 
 void commitDoNotDisturbChanges(void)
 {
-    NSLog(@"--- CommitDND");
     /// XXX: I'm using kCFPreferencesCurrentUser placeholder here which means that this code must
     /// be run under regular user's account (not root/admin). If you're going to run this code
     /// from a privileged helper, use kCFPreferencesAnyUser in order to toggle DND for all users

--- a/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
+++ b/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
@@ -49,10 +49,29 @@
     [eventBus subscribeTo:POMODORO_START subscriber:^(id eventData) {
         [ui switchToPomodoroState];
         [self dispatchNewNotification:@"Pomodoro started"];
+        NSLog(@"%d --- ENABLE DND", [preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]);
+        if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                         1 * NSEC_PER_SEC),
+                           dispatch_get_main_queue(),
+                           ^{
+                               turnDoNotDisturbOn();
+                           });
+            
+        }
     }];
     
     [eventBus subscribeTo:TIMER_STOP subscriber:^(id eventData) {
         [ui switchToIdleState];
+        if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     1 * NSEC_PER_SEC),
+                       dispatch_get_main_queue(),
+                       ^{
+                           NSLog(@"--- DISABLE DND");
+                           turnDoNotDisturbOff();
+                       });
+        }
     }];
     
     [eventBus subscribeTo:SHORT_BREAK_START subscriber:^(id eventData) {
@@ -83,5 +102,62 @@
         }
     }];
 }
+
+///
+/// This block of code for turning Do Not Disturb on and off
+/// is directly from https://stackoverflow.com/a/36385778/518130
+///
+void turnDoNotDisturbOn(void)
+{
+    // The trick is to set DND time range from 00:00 (0 minutes) to 23:59 (1439 minutes),
+    // so it will always be on
+    CFPreferencesSetValue(CFSTR("dndStart"), (__bridge CFPropertyListRef)(@(0.0f)),
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    CFPreferencesSetValue(CFSTR("dndEnd"), (__bridge CFPropertyListRef)(@(1440.f)),
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    CFPreferencesSetValue(CFSTR("doNotDisturb"), (__bridge CFPropertyListRef)(@(YES)),
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    // Notify all the related daemons that we have changed Do Not Disturb preferences
+    commitDoNotDisturbChanges();
+}
+
+
+void turnDoNotDisturbOff()
+{
+    CFPreferencesSetValue(CFSTR("dndStart"), NULL,
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    CFPreferencesSetValue(CFSTR("dndEnd"), NULL,
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    CFPreferencesSetValue(CFSTR("doNotDisturb"), (__bridge CFPropertyListRef)(@(NO)),
+                          CFSTR("com.apple.notificationcenterui"),
+                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    
+    commitDoNotDisturbChanges();
+}
+
+void commitDoNotDisturbChanges(void)
+{
+    NSLog(@"--- CommitDND");
+    /// XXX: I'm using kCFPreferencesCurrentUser placeholder here which means that this code must
+    /// be run under regular user's account (not root/admin). If you're going to run this code
+    /// from a privileged helper, use kCFPreferencesAnyUser in order to toggle DND for all users
+    /// or drop privileges and use kCFPreferencesCurrentUser.
+    CFPreferencesSynchronize(CFSTR("com.apple.notificationcenterui"), kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
+    [[NSDistributedNotificationCenter defaultCenter] postNotificationName: @"com.apple.notificationcenterui.dndprefs_changed"
+                                                                   object: nil userInfo: nil
+                                                       deliverImmediately: YES];
+}
+
+
 
 @end

--- a/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
+++ b/src/Tomighty/Core/Agent/TYUserInterfaceAgent.m
@@ -61,9 +61,23 @@
         }
     }];
     
-    [eventBus subscribeTo:TIMER_STOP subscriber:^(id eventData) {
-        [ui switchToIdleState];
+    [eventBus subscribeTo:POMODORO_COMPLETE subscriber:^(id eventData) {
+        
         if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
+            turnDoNotDisturbOff();
+        }
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                     1 * NSEC_PER_SEC),
+                       dispatch_get_main_queue(),
+                       ^{
+                           NSLog(@"--- Pomodoro complete");
+                           [self dispatchNewNotification:@"Pomodoro completed"];
+                       });
+        
+    }];
+    
+    [eventBus subscribeTo:TIMER_STOP subscriber:^(id eventData) {
+        /*if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                      1 * NSEC_PER_SEC),
                        dispatch_get_main_queue(),
@@ -71,7 +85,11 @@
                            NSLog(@"--- DISABLE DND");
                            turnDoNotDisturbOff();
                        });
+        }*/
+        if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
+            turnDoNotDisturbOff();
         }
+        [ui switchToIdleState];
     }];
     
     [eventBus subscribeTo:SHORT_BREAK_START subscriber:^(id eventData) {

--- a/src/Tomighty/Core/Preferences/TYPreferences.h
+++ b/src/Tomighty/Core/Preferences/TYPreferences.h
@@ -23,6 +23,7 @@ extern NSString * const PREF_HOTKEY_START;
 extern NSString * const PREF_HOTKEY_STOP;
 extern NSString * const PREF_CONTINUOUS_MODE;
 extern NSString * const PREF_ENABLE_NOTIFICATIONS;
+extern NSString * const PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO;
 
 @protocol TYPreferences <NSObject>
 

--- a/src/Tomighty/Core/Preferences/TYUserDefaultsPreferences.m
+++ b/src/Tomighty/Core/Preferences/TYUserDefaultsPreferences.m
@@ -26,6 +26,8 @@ int const PREF_STATUS_ICON_TIME_FORMAT_SECONDS = 2;
 NSString * const PREF_HOTKEY_START = @"org.tomighty.hotkey.start";
 NSString * const PREF_HOTKEY_STOP = @"org.tomighty.hotkey.stop";
 NSString * const PREF_ENABLE_NOTIFICATIONS = @"org.tomighty.enable_notifications";
+NSString * const PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO = @"org.tomighty.enable_do_not_disturb_during_pomodoro";
+
 
 @implementation TYUserDefaultsPreferences
 {
@@ -51,6 +53,7 @@ NSString * const PREF_ENABLE_NOTIFICATIONS = @"org.tomighty.enable_notifications
         [defaultValues setObject:[NSNumber numberWithInt:true] forKey:PREF_PLAY_TICKTOCK_SOUND_DURING_BREAK];
         [defaultValues setObject:[NSNumber numberWithInt:true] forKey:PREF_CONTINUOUS_MODE];
         [defaultValues setObject:[NSNumber numberWithInt:false] forKey:PREF_ENABLE_NOTIFICATIONS];
+        [defaultValues setObject:[NSNumber numberWithInt:false] forKey:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO];
         [defaultValues setObject:[NSNumber numberWithInt:PREF_STATUS_ICON_TIME_FORMAT_NONE] forKey:PREF_STATUS_ICON_TIME_FORMAT];
         [defaultValues setObject:@"^⌘P" forKey:PREF_HOTKEY_START];
         [defaultValues setObject:@"^⌘S" forKey:PREF_HOTKEY_STOP];

--- a/src/Tomighty/Core/TYDefaultTomighty.m
+++ b/src/Tomighty/Core/TYDefaultTomighty.m
@@ -96,7 +96,6 @@
 
 - (void)startShortBreak
 {
-
     [self startTimer:SHORT_BREAK
          contextName:@"Short break"
              minutes:[preferences getInt:PREF_TIME_SHORT_BREAK]];
@@ -104,9 +103,6 @@
 
 - (void)startLongBreak
 {
-    //if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
-    //    turnDoNotDisturbOff();
-    //}
     [self startTimer:LONG_BREAK
          contextName:@"Long break"
              minutes:[preferences getInt:PREF_TIME_LONG_BREAK]];

--- a/src/Tomighty/Core/TYDefaultTomighty.m
+++ b/src/Tomighty/Core/TYDefaultTomighty.m
@@ -89,11 +89,6 @@
 
 - (void)startPomodoro
 {
-    NSLog(@"%d --- TEST", [preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]);
-    if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
-        sleep(0.5);
-        turnDoNotDisturbOn();
-    }
     [self startTimer:POMODORO
          contextName:@"Pomodoro"
              minutes:[preferences getInt:PREF_TIME_POMODORO]];
@@ -101,9 +96,7 @@
 
 - (void)startShortBreak
 {
-    //if ([preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]) {
-    //    turnDoNotDisturbOff();
-    //}
+
     [self startTimer:SHORT_BREAK
          contextName:@"Short break"
              minutes:[preferences getInt:PREF_TIME_SHORT_BREAK]];
@@ -208,62 +201,5 @@ OSStatus TYHotkeyHandler(EventHandlerCallRef next, EventRef evt, void *data) {
     }
     return noErr;
 }
-
-
-///
-/// This block of code for turning Do Not Disturb on and off
-/// is directly from https://stackoverflow.com/a/36385778/518130
-///
-void turnDoNotDisturbOn(void)
-{
-    // The trick is to set DND time range from 00:00 (0 minutes) to 23:59 (1439 minutes),
-    // so it will always be on
-    CFPreferencesSetValue(CFSTR("dndStart"), (__bridge CFPropertyListRef)(@(0.0f)),
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    CFPreferencesSetValue(CFSTR("dndEnd"), (__bridge CFPropertyListRef)(@(1440.f)),
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    CFPreferencesSetValue(CFSTR("doNotDisturb"), (__bridge CFPropertyListRef)(@(YES)),
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    // Notify all the related daemons that we have changed Do Not Disturb preferences
-    commitDoNotDisturbChanges();
-}
-
-
-void turnDoNotDisturbOff()
-{
-    CFPreferencesSetValue(CFSTR("dndStart"), NULL,
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    CFPreferencesSetValue(CFSTR("dndEnd"), NULL,
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    CFPreferencesSetValue(CFSTR("doNotDisturb"), (__bridge CFPropertyListRef)(@(NO)),
-                          CFSTR("com.apple.notificationcenterui"),
-                          kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    
-    commitDoNotDisturbChanges();
-}
-
-void commitDoNotDisturbChanges(void)
-{
-    NSLog(@"--- CommitDND");
-    /// XXX: I'm using kCFPreferencesCurrentUser placeholder here which means that this code must
-    /// be run under regular user's account (not root/admin). If you're going to run this code
-    /// from a privileged helper, use kCFPreferencesAnyUser in order to toggle DND for all users
-    /// or drop privileges and use kCFPreferencesCurrentUser.
-    CFPreferencesSynchronize(CFSTR("com.apple.notificationcenterui"), kCFPreferencesCurrentUser, kCFPreferencesCurrentHost);
-    [[NSDistributedNotificationCenter defaultCenter] postNotificationName: @"com.apple.notificationcenterui.dndprefs_changed"
-                                                                   object: nil userInfo: nil
-                                                       deliverImmediately: YES];
-}
-
 
 @end

--- a/src/Tomighty/Core/UI/TYPreferencesWindowController.h
+++ b/src/Tomighty/Core/UI/TYPreferencesWindowController.h
@@ -22,6 +22,7 @@
 @property (weak) IBOutlet NSButton *check_play_ticktock_sound_during_pomodoro;
 @property (weak) IBOutlet NSButton *check_play_ticktock_sound_during_break;
 @property (weak) IBOutlet NSButton *check_show_notifications;
+@property (weak) IBOutlet NSButton *check_enable_do_not_disturb_during_pomodoro;
 @property (weak) IBOutlet NSButton *check_continuous_mode;
 @property (weak) IBOutlet NSPopUpButton *popup_status_icon_time_format;
 @property (weak) IBOutlet TYHotkeyControl *text_hotkey_start;
@@ -40,5 +41,6 @@
 - (IBAction)save_hotkey_start:(id)sender;
 - (IBAction)save_hotkey_stop:(id)sender;
 - (IBAction)save_show_notifications:(id)sender;
+- (IBAction)save_enable_do_not_disturb_during_pomodoro:(id)sender;
 
 @end

--- a/src/Tomighty/Core/UI/TYPreferencesWindowController.m
+++ b/src/Tomighty/Core/UI/TYPreferencesWindowController.m
@@ -39,6 +39,7 @@
     [self.check_play_ticktock_sound_during_pomodoro setState:[preferences getInt:PREF_PLAY_TICKTOCK_SOUND_DURING_POMODORO]];
     [self.check_play_ticktock_sound_during_break setState:[preferences getInt:PREF_PLAY_TICKTOCK_SOUND_DURING_BREAK]];
     [self.check_show_notifications setState:[preferences getInt:PREF_ENABLE_NOTIFICATIONS]];
+    [self.check_enable_do_not_disturb_during_pomodoro setState:[preferences getInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO]];
     [self.check_continuous_mode setState:[preferences getInt:PREF_CONTINUOUS_MODE]];
     [self.popup_status_icon_time_format selectItemAtIndex:[preferences getInt:PREF_STATUS_ICON_TIME_FORMAT]];
     [self.text_hotkey_start
@@ -88,6 +89,10 @@
 
 - (IBAction)save_show_notifications:(id)sender {
     [preferences setInt:PREF_ENABLE_NOTIFICATIONS value:(int)[self.check_show_notifications state]];
+}
+
+- (IBAction)save_enable_do_not_disturb_during_pomodoro:(id)sender {
+    [preferences setInt:PREF_ENABLE_DO_NOT_DISTURB_DURING_POMODORO value:(int)[self.check_enable_do_not_disturb_during_pomodoro state]];
 }
 
 - (IBAction)save_continuous_mode:(id)sender {


### PR DESCRIPTION
Add "Enable Do Not Disturb during Pomodoro" option under Notifications

Enables toggling the Do Not Disturb option in Notification Center.

Enables DND when Pomodoro timer starts
Disables DND when Pomodoro timer completes


![screen shot 2018-03-16 at 4 53 11 pm](https://user-images.githubusercontent.com/21967/37546493-11216cae-293b-11e8-8b40-dc3462508d5d.png)

This implementation should satisfy #45, but I would appreciate feedback.

CC @mtavkhelidze @ccidral @dvntucker @dzindra 